### PR TITLE
Refactoring usePushOwl hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,33 @@ For `priceDrop` and `backInStock`
 
 ### `syncCart`
 
-Cart syncing is auto-enabled in this module. This API gets called automatically whenever the cart is updated.
+```javascript
+import { useCartState, processCart } from "frontend-checkout";
+
+const cart = useCartState();
+const cartId = cart.id;
+const cartItems = cart.items;
+
+React.useEffect(() => {
+  if (hasLoaded && cartItems && cartId) {
+    window.pushowl.trigger("syncCart", processCart({ cartItems, cartId }));
+  }
+}, [cartId, cartItems, hasLoaded]);
+```
+
+### `customerSync`
+
+```javascript
+import { useCustomerState, processCustomerId } from "frontend-customer";
+
+const { id: customerId } = useCustomerState();
+
+React.useEffect(() => {
+  if (hasLoaded && customerId) {
+    window.pushowl.trigger("setCustomerId", processCustomerId({ customerId }));
+  }
+}, [customerId, hasLoaded]);
+```
 
 ## Recipes
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ For `priceDrop` and `backInStock`
 ### `syncCart`
 
 ```javascript
-import { useCartState, processCart } from "frontend-checkout";
+import { useCartState } from "frontend-checkout";
+import { processCart } from "@pushowl/shogun-frontend-sdk";
 
 const cart = useCartState();
 const cartId = cart.id;
@@ -177,7 +178,8 @@ React.useEffect(() => {
 ### `customerSync`
 
 ```javascript
-import { useCustomerState, processCustomerId } from "frontend-customer";
+import { useCustomerState } from "frontend-customer";
+import { processCustomerId } from "@pushowl/shogun-frontend-sdk";
 
 const { id: customerId } = useCustomerState();
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ React.useEffect(() => {
 
 ```javascript
 import { useCustomerState } from "frontend-customer";
-import { processCustomerId } from "@pushowl/shogun-frontend-sdk";
-import { usePushowl } from "@pushowl/shogun-frontend-sdk";
+import { processCustomerId, usePushowl } from "@pushowl/shogun-frontend-sdk";
 
 const { hasLoaded } = usePushowl("your-shopify-subdomain");
 const { id: customerId } = useCustomerState();

--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ For `priceDrop` and `backInStock`
 
 ```javascript
 import { useCartState } from "frontend-checkout";
-import { processCart } from "@pushowl/shogun-frontend-sdk";
-import { usePushowl } from "@pushowl/shogun-frontend-sdk";
+import { processCart, usePushowl } from "@pushowl/shogun-frontend-sdk";
 
 const { hasLoaded } = usePushowl("your-shopify-subdomain");
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ If the store URL you see above is not the right store URL where products are ava
 You need to enable `externalId` and `storefrontId` for product and variants in your `ProductBox` section and then call the following effect in your code
 
 ```js
+import { usePushowl } from "@pushowl/shogun-frontend-sdk";
+
+const { hasLoaded } = usePushowl("your-shopify-subdomain");
+
 React.useEffect(() => {
   if (hasLoaded && product) {
     window.pushowl.trigger("syncProductView", { productId: product.id });
@@ -77,6 +81,10 @@ React.useEffect(() => {
 In your `ProductBox` section you can call the following effect
 
 ```js
+import { usePushowl } from "@pushowl/shogun-frontend-sdk";
+
+const { hasLoaded } = usePushowl("your-shopify-subdomain");
+
 React.useEffect(() => {
   if (product && hasLoaded) {
     async function showProductWidget() {
@@ -163,6 +171,9 @@ For `priceDrop` and `backInStock`
 ```javascript
 import { useCartState } from "frontend-checkout";
 import { processCart } from "@pushowl/shogun-frontend-sdk";
+import { usePushowl } from "@pushowl/shogun-frontend-sdk";
+
+const { hasLoaded } = usePushowl("your-shopify-subdomain");
 
 const cart = useCartState();
 const cartId = cart.id;
@@ -180,7 +191,9 @@ React.useEffect(() => {
 ```javascript
 import { useCustomerState } from "frontend-customer";
 import { processCustomerId } from "@pushowl/shogun-frontend-sdk";
+import { usePushowl } from "@pushowl/shogun-frontend-sdk";
 
+const { hasLoaded } = usePushowl("your-shopify-subdomain");
 const { id: customerId } = useCustomerState();
 
 React.useEffect(() => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,8 +21,6 @@ module.exports = {
     "!./packages/*/src/**/*.stories.tsx",
     "!./packages/*/src/**/*.mock.ts",
     "!./packages/*/src/index.ts",
-    "!./packages/frontend-customer/**/*.{ts,tsx}",
-    "!./packages/frontend-checkout/**/*.{ts,tsx}",
   ],
   globals: {
     "ts-jest": {

--- a/package.json
+++ b/package.json
@@ -40,14 +40,10 @@
   },
   "peerDependencies": {
     "@types/react": "^17.0.0",
-    "frontend-checkout": "^3.3.7-alpha.1",
-    "frontend-customer": "^2.0.4",
     "react": "^17.0.0"
   },
   "dependencies": {
     "faker": "^5.2.0",
-    "frontend-checkout": "^3.3.7-alpha.1",
-    "frontend-customer": "^2.0.4",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "tslib": "^2.1.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { usePushowl } from './use-pushowl'
+export { usePushowl, processCustomerId, processCart } from "./use-pushowl";

--- a/src/use-pushowl.ts
+++ b/src/use-pushowl.ts
@@ -22,12 +22,13 @@ const getVariantIdFromItem = (item: any): string => {
   return "";
 };
 
-export const processCart = (taskInput: {
+export const processCart = ({
+  cartItems,
+  cartId,
+}: {
   cartId: string;
   cartItems: Array<any>;
 }) => {
-  const { cartItems, cartId } = taskInput;
-
   const items = cartItems.map((item) => {
     const productWithCheckout = atob(item.id).split("/").pop();
 
@@ -64,8 +65,7 @@ export const processCart = (taskInput: {
   };
 };
 
-export const processCustomerId = (taskInput: { customerId: string }) => {
-  const { customerId } = taskInput;
+export const processCustomerId = ({ customerId }: { customerId: string }) => {
   const decodedCustomerId = atob(`${customerId}`).split("/").pop();
   if (decodedCustomerId !== undefined) {
     return parseInt(decodedCustomerId);

--- a/src/use-pushowl.ts
+++ b/src/use-pushowl.ts
@@ -1,137 +1,134 @@
-import { useEffect, useState } from 'react'
-import { useCartState } from 'frontend-checkout'
-import { useCustomerState } from 'frontend-customer'
-import { StorePlatformDomain, Pushowl } from './types'
+import { useEffect, useState } from "react";
+import { StorePlatformDomain, Pushowl } from "./types";
 
 const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
-    typeof value === 'object' && value !== null && !Array.isArray(value)
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const getVariantIdFromItem = (item: any): string => {
-    // eslint-disable-next-line no-prototype-builtins
-    if (isRecord(item) && isRecord(item.variant) && item.variant.hasOwnProperty('id')) {
-        return `${item.variant.id}`
+  // eslint-disable-next-line no-prototype-builtins
+  if (
+    isRecord(item) &&
+    isRecord(item.variant) &&
+    item.variant.hasOwnProperty("id")
+  ) {
+    return `${item.variant.id}`;
+  }
+
+  // eslint-disable-next-line no-prototype-builtins
+  if (isRecord(item) && item.hasOwnProperty("variant_id")) {
+    return `${item.variant_id}`;
+  }
+
+  return "";
+};
+
+const processCart = (taskInput: { cartId: string; cartItems: Array<any> }) => {
+  const { cartItems, cartId } = taskInput;
+
+  const items = cartItems.map((item) => {
+    const productWithCheckout = atob(item.id).split("/").pop();
+
+    let productId = null;
+
+    if (productWithCheckout !== undefined && productWithCheckout.length > 0) {
+      productId = parseInt(productWithCheckout.split("?checkout=")[0], 10);
     }
 
-    // eslint-disable-next-line no-prototype-builtins
-    if (isRecord(item) && item.hasOwnProperty('variant_id')) {
-        return `${item.variant_id}`
+    const variantIdStr = atob(getVariantIdFromItem(item)).split("/").pop();
+    let variantId = null;
+
+    if (variantIdStr !== undefined) {
+      variantId = parseInt(variantIdStr, 10);
     }
-
-    return ''
-}
-
-export const usePushowl = (subdomain: string) => {
-    const cart = useCartState()
-    const [hasLoaded, setHasLoaded] = useState(false)
-    const { id: customerId } = useCustomerState()
-    const cartId = cart.id
-
-    const cartItems = cart.items
-
-    // Injecting pushowl script to the store
-    useEffect(() => {
-        if (document.querySelector('[data-script="pushowl"]')) {
-            setHasLoaded(true)
-            return
-        }
-
-        const injectScript = (subdomain: StorePlatformDomain | null) => {
-            if (!window.pushowl) {
-                const pushowl: Pushowl = {
-                    queue: [],
-                    subdomain,
-                    trigger: (
-                        taskName: string,
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        taskData: any,
-                    ) => {
-                        return new Promise((resolve, reject) => {
-                            window.pushowl.queue.push({
-                                taskName,
-                                taskData,
-                                promise: { resolve, reject },
-                            })
-                        })
-                    },
-                    init: () => {
-                        if (subdomain === null) {
-                            return
-                        }
-
-                        const script = document.createElement('script')
-                        script.type = 'text/javascript'
-                        script.async = true
-                        script.src = `https://cdn.pushowl.com/sdks/pushowl-sdk.js?subdomain=${subdomain}&environment=production&shop=${subdomain}.myshopify.com`
-                        script.dataset.script = "pushowl";
-                        document.body.append(script)
-                        script.addEventListener('load', () => {
-                            setHasLoaded(true)
-                        })
-
-                        return script
-                    },
-                }
-
-                window.pushowl = pushowl
-            }
-
-            window.pushowl.init()
-        }
-
-        injectScript(subdomain)
-    }, [subdomain, hasLoaded])
-
-    // Syncing customer id
-    useEffect(() => {
-        if (customerId !== null && hasLoaded) {
-            const decodedCustomerId = atob(`${customerId}`).split('/').pop()
-            if (decodedCustomerId !== undefined) {
-                window.pushowl.trigger('setCustomerId', parseInt(decodedCustomerId))
-            }
-        }
-    }, [customerId, hasLoaded])
-
-    // sync cart when its items change
-    useEffect(() => {
-        if (cartId !== null && hasLoaded) {
-            const items = cartItems.map((item) => {
-                const productWithCheckout = atob(item.id).split('/').pop()
-
-                let productId = null
-
-                if (productWithCheckout !== undefined && productWithCheckout.length > 0) {
-                    productId = parseInt(productWithCheckout.split('?checkout=')[0], 10)
-                }
-
-                const variantIdStr = atob(getVariantIdFromItem(item)).split('/').pop()
-                let variantId = null
-
-                if (variantIdStr !== undefined) {
-                    variantId = parseInt(variantIdStr, 10)
-                }
-
-                return {
-                    variantId,
-                    productId,
-                    quantity: item.quantity,
-                }
-            })
-
-            let checkoutToken = null
-            const checkoutTokenWithKey = atob(cartId).split('/').pop()
-
-            if (checkoutTokenWithKey !== undefined) {
-                checkoutToken = checkoutTokenWithKey.split('?key=')[0]
-            }
-
-            window.pushowl.trigger('syncCart', {
-                items,
-                checkoutToken,
-            })
-        }
-    }, [hasLoaded, cartId, cartItems])
 
     return {
-        hasLoaded,
+      variantId,
+      productId,
+      quantity: item.quantity,
+    };
+  });
+
+  let checkoutToken = null;
+  const checkoutTokenWithKey = atob(cartId).split("/").pop();
+
+  if (checkoutTokenWithKey !== undefined) {
+    checkoutToken = checkoutTokenWithKey.split("?key=")[0];
+  }
+
+  return {
+    items,
+    checkoutToken,
+  };
+};
+
+const processCustomerId = (taskInput: { customerId: string }) => {
+  const { customerId } = taskInput;
+  const decodedCustomerId = atob(`${customerId}`).split("/").pop();
+  if (decodedCustomerId !== undefined) {
+    return parseInt(decodedCustomerId);
+  }
+  return null;
+};
+
+export const usePushowl = (subdomain: string) => {
+  const [hasLoaded, setHasLoaded] = useState(false);
+
+  // Injecting pushowl script to the store
+  useEffect(() => {
+    if (document.querySelector('[data-script="pushowl"]')) {
+      setHasLoaded(true);
+      return;
     }
-}
+
+    const injectScript = (subdomain: StorePlatformDomain | null) => {
+      if (!window.pushowl) {
+        const pushowl: Pushowl = {
+          queue: [],
+          subdomain,
+          trigger: (
+            taskName: string,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            taskData: any
+          ) => {
+            return new Promise((resolve, reject) => {
+              window.pushowl.queue.push({
+                taskName,
+                taskData,
+                promise: { resolve, reject },
+              });
+            });
+          },
+          init: () => {
+            if (subdomain === null) {
+              return;
+            }
+
+            const script = document.createElement("script");
+            script.type = "text/javascript";
+            script.async = true;
+            script.src = `https://cdn.pushowl.com/sdks/pushowl-sdk.js?subdomain=${subdomain}&environment=production&shop=${subdomain}.myshopify.com`;
+            script.dataset.script = "pushowl";
+            document.body.append(script);
+            script.addEventListener("load", () => {
+              setHasLoaded(true);
+            });
+
+            return script;
+          },
+        };
+
+        window.pushowl = pushowl;
+      }
+
+      window.pushowl.init();
+    };
+
+    injectScript(subdomain);
+  }, [subdomain, hasLoaded]);
+
+  return {
+    hasLoaded,
+    processCustomerId,
+    processCart,
+  };
+};

--- a/src/use-pushowl.ts
+++ b/src/use-pushowl.ts
@@ -22,7 +22,10 @@ const getVariantIdFromItem = (item: any): string => {
   return "";
 };
 
-const processCart = (taskInput: { cartId: string; cartItems: Array<any> }) => {
+export const processCart = (taskInput: {
+  cartId: string;
+  cartItems: Array<any>;
+}) => {
   const { cartItems, cartId } = taskInput;
 
   const items = cartItems.map((item) => {
@@ -61,7 +64,7 @@ const processCart = (taskInput: { cartId: string; cartItems: Array<any> }) => {
   };
 };
 
-const processCustomerId = (taskInput: { customerId: string }) => {
+export const processCustomerId = (taskInput: { customerId: string }) => {
   const { customerId } = taskInput;
   const decodedCustomerId = atob(`${customerId}`).split("/").pop();
   if (decodedCustomerId !== undefined) {
@@ -128,7 +131,5 @@ export const usePushowl = (subdomain: string) => {
 
   return {
     hasLoaded,
-    processCustomerId,
-    processCart,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,16 +1609,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-frontend-checkout@^3.3.7-alpha.1:
-  version "3.3.7-alpha.1"
-  resolved "https://registry.yarnpkg.com/frontend-checkout/-/frontend-checkout-3.3.7-alpha.1.tgz#f84f3c6625c4fcd2eecdd46a39e046d97244e85a"
-  integrity sha512-JXzfjnjAA98M2kLe4GgAOgwmgt1y7MIC0LsI4K/niN7MX1VC7dtVz+2yDwOlur8fdVBHus238MbDFhkG+drbRA==
-
-frontend-customer@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/frontend-customer/-/frontend-customer-2.0.4.tgz#68dafca8dbb141bd625e3fd8bfb166768883d905"
-  integrity sha512-rn/nZ9iNJExlb8u1MDz8n2OXipwI+v3BbmLWeZ3TJ0rAllSx/wNQKvDJj+miI09fdyQH0vv16qDi17neWIM5KQ==
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"


### PR DESCRIPTION
* Refactoring usePushOwl hook to remove dependency  `frontend-checkout` and  `frontend-customer`
* This will make our code simpler and allow us to multiple versions of these packages (even if they are not backwards compatible)
* We now expose two util functions to help with cart sync and customer sync. That merchant can use instead of us calling sync manually